### PR TITLE
feat: link to video on CDN via S3 and Cloudflare

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -11,6 +11,6 @@ npx concurrently \
   --prefix-colors "bgRed.bold.white,bgGreen.bold.white,bgBlue.bold.white,bgMagenta.bold.white,bgCyan.bold.white" \
   "npm run lint --silent" \
   "npm run check-types --silent" \
-  "npm run prettier:ci --silent -- --loglevel silent" \
+  "npm run prettier:ci --silent -- --log-level silent" \
   "terraform -chdir=$TERRAFORM_DIRECTORY validate" \
   "terraform -chdir=$TERRAFORM_DIRECTORY fmt"

--- a/infrastructure/cloudfront-functions/rewrite-spa-uri.js
+++ b/infrastructure/cloudfront-functions/rewrite-spa-uri.js
@@ -1,0 +1,15 @@
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+  
+  // Don't modify URIs that end with a `/`
+  if (uri.endsWith('/')) {
+      return request;
+  } 
+  // Check whether the URI is missing a file extension.
+  if (!uri.includes('.')) {
+      request.uri += '.html';
+  }
+
+  return request;
+}

--- a/infrastructure/scripts/sync-s3-bucket.sh
+++ b/infrastructure/scripts/sync-s3-bucket.sh
@@ -16,7 +16,7 @@ echo "ℹ️  S3_BUCKET_NAME set to ${S3_BUCKET_NAME}"
 echo
 
 echo "⚒  Building and exporting"
-npm run build && npm run export
+npm run build
 echo
 
 echo "🗑  Cleaning up S3 bucket: deleting all files recursively"

--- a/infrastructure/terraform/cloudfront-function.tf
+++ b/infrastructure/terraform/cloudfront-function.tf
@@ -1,0 +1,7 @@
+resource "aws_cloudfront_function" "rewriteUri" {
+  name    = "rewriteUriSpa"
+  runtime = "cloudfront-js-1.0"
+  code    = file("${path.root}/../cloudfront-functions/rewrite-spa-uri.js")
+  publish = true
+  comment = "NextJS files are not found based on URI because of how next export works with S3. This function appends .html to the files, so they are found via their URI."
+}

--- a/infrastructure/terraform/cloudfront.tf
+++ b/infrastructure/terraform/cloudfront.tf
@@ -40,6 +40,13 @@ module "cloudfront" {
     allowed_methods = ["GET", "HEAD", "OPTIONS"]
     cached_methods  = ["GET", "HEAD"]
     compress        = true
+
+    function_association = {
+      # Valid keys: viewer-request, viewer-response
+      viewer-request = {
+        function_arn = aws_cloudfront_function.rewriteUri.arn
+      }
+    }
   }
 
   custom_error_response = [{

--- a/infrastructure/terraform/cloudfront.tf
+++ b/infrastructure/terraform/cloudfront.tf
@@ -45,10 +45,10 @@ module "cloudfront" {
   custom_error_response = [{
     error_code         = 404
     response_code      = 200
-    response_page_path = "/index.html"
+    response_page_path = "/404.html"
     }, {
     error_code         = 403
     response_code      = 200
-    response_page_path = "/index.html"
+    response_page_path = "/404.html"
   }]
 }

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -37,4 +37,5 @@ variable "ssm_enabled" {
 variable "ssm_base_path" {
   type        = string
   description = "Prefix for ssm parameters"
+  default     = "/m-rc"
 }

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@ const withExportImages = require('next-export-optimize-images');
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  output: 'export',
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "check-types": "tsc --noEmit",
     "commit": "cz",
     "prepare": "husky install",
-    "clean": "rm -rf .next/ && rm -rf out/"
+    "clean": "rm -rf .next/ && rm -rf out/",
+    "serve-build": "npx http-server out/"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.17",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
-    "export": "next export && next-export-optimize-images",
+    "build": "next build && next-export-optimize-images",
     "start": "next start",
     "lint": "next lint",
     "prettier": "prettier --write --cache .",

--- a/pages/video-test.tsx
+++ b/pages/video-test.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/Layout';
+
+export default function VideoTest() {
+  return (
+    <Layout>
+      Test video page - the video URL will be broken soon.
+      <video controls width="250">
+        <source
+          src="https://video.m-rc.nl/assets/flower.webm"
+          type="video/webm"
+        />
+      </video>
+    </Layout>
+  );
+}


### PR DESCRIPTION
Note: Most changes are actually merged with this PR: https://github.com/m-goos/m-rc/pull/2

## Goal
Prototyping an S3 bucket with Cloudflare in front of it.

## TODO
- [x] Remove manually created Cloudflare and S3 resources

## Implementation
CNAME record proxies video.m-rc.nl/ to the S3 bucket.
The S3 bucket is set to webhosting and has a public ACL **BUT** only allows cloudflare IPs.

A build is deployed and is accessible at https://m-rc.nl/video-test.html
The asset in the public bucket is not accessible via the public S3 endpoint - as intended:
- File endpoint: https://s3.eu-west-1.amazonaws.com/video.m-rc.nl/assets/flower.webm
- Website endpoint: http://video.m-rc.nl.s3-website-eu-west-1.amazonaws.com/assets/flower.webm

## Reference: architecture

<img width="834" alt="image" src="https://github.com/m-goos/m-rc/assets/10080192/6d3391e0-818f-4731-a21c-724edee032bd">

As intended:

<img width="958" alt="image" src="https://github.com/m-goos/m-rc/assets/10080192/e81ba5e0-96bd-42fa-9a0c-ae09f53b7550">
