### PR TITLE
fix: css width problem

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -23,3 +23,4 @@ This is the place to collect all TODOs. As a reminder to myself: Before I pick s
 - [ ] draft-status for blogs and a button to show/hide them
 - [ ] optimize images
 - [ ] mailing list: signup + alerting
+- [ ] storybook or something similar (simpler) for the components I build

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,8 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <div className="flex justify-center min-h-screen bg-slate-50">
+        <div className="flex flex-col justify-center min-h-screen bg-slate-50">
+          {/* element below is too wide */}
           <div className="flex flex-col grow max-w-2xl px-4">
             <Nav />
             <main className="flex flex-col py-8">{children}</main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,11 +2,8 @@ import Nav from '@/components/Nav';
 
 // These styles apply to every route in the application
 import './globals.css';
-import Info from '@/components/Info';
 
 export default function RootLayout({
-  // Layouts must accept a children prop.
-  // This will be populated with nested layouts or pages
   children,
 }: {
   children: React.ReactNode;
@@ -14,17 +11,14 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <div className="flex flex-col justify-center min-h-screen bg-slate-50">
-          {/* element below is too wide */}
-          <div className="flex flex-col grow max-w-2xl px-4">
-            <Nav />
-            <Info
-              message={
-                'Work in progress - currently fixing a CSS-bug related to flex alignment'
-              }
-              prLink={'https://github.com/m-goos/m-rc/pull/7'}
-            />
-            <main className="flex flex-col py-8">{children}</main>
+        <div className="flex flex-col items-center min-h-screen bg-slate-50">
+          {/* this container sets a flexible max width that's always maxed out */}
+          <div className="flex grow max-w-xl w-full">
+            {/* provide padding and keep blogs constrained to 100% width */}
+            <div className="flex flex-col w-full px-4">
+              <Nav />
+              <main className="flex flex-col py-8">{children}</main>
+            </div>
           </div>
         </div>
       </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import Nav from '@/components/Nav';
 
 // These styles apply to every route in the application
 import './globals.css';
+import Info from '@/components/Info';
 
 export default function RootLayout({
   // Layouts must accept a children prop.
@@ -17,6 +18,12 @@ export default function RootLayout({
           {/* element below is too wide */}
           <div className="flex flex-col grow max-w-2xl px-4">
             <Nav />
+            <Info
+              message={
+                'Work in progress - currently fixing a CSS-bug related to flex alignment'
+              }
+              prLink={'https://github.com/m-goos/m-rc/pull/7'}
+            />
             <main className="flex flex-col py-8">{children}</main>
           </div>
         </div>

--- a/components/Info.tsx
+++ b/components/Info.tsx
@@ -1,0 +1,29 @@
+type InfoProps = {
+  /** Inform the user about what is going on: 'Currently working on a CSS bug related to flex alignment' */
+  message: string;
+  /** URL for the PR that shows the work-in-progress: 'https://github.com/m-goos/m-rc/pull/7'  */
+  prLink?: string;
+};
+
+export default function Info({ message, prLink }: InfoProps) {
+  return (
+    <div className="flex flex-col rounded-md bg-blue-100 font-medium text-sm text-slate-600 p-3 my-2">
+      <div className="flex">
+        <span className="inline-flex justify-center items-center h-5 w-5 rounded-full bg-blue-500 text-blue-100 p-2 mr-3 text-center text-xs">
+          i
+        </span>
+        <div className="flex flex-col space-x-1">
+          {message}
+          {prLink && (
+            <span className="text-slate-400">
+              Open PR:{' '}
+              <a className="text-blue-500 hover:text-blue-800" href={prLink}>
+                {prLink}
+              </a>
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
> ℹ️ Status: investigating..

- css bug 1: blogs overflow on small screens
- css bug 2: the layout is different a different width for the blog - try toggling between different navbar items to see a slight shift

## Overflow problem
On laptop screens, the horizontal alignment of the blog is good.

On mobile devices, there seems to be a problem. Some blogs render fine, other posts have a problem:
- overflow outside of the parent
- part of the blog can be seen when zooming out, although it looks ugly
- part disappears..

Examples:

![image](https://github.com/m-goos/m-rc/assets/10080192/b7836ea2-facc-4f66-a902-7da61afe8a75)
![image](https://github.com/m-goos/m-rc/assets/10080192/cd2e840e-1125-4598-bff6-37f41415efe9)
![image](https://github.com/m-goos/m-rc/assets/10080192/b1130c74-6741-4b82-90ba-920fb23349c3)

Some posts are fine:
![image](https://github.com/m-goos/m-rc/assets/10080192/f6012031-5f85-455d-9cb9-91359d07205a)
