### PR TITLE
ci(pre-commit): disable terraform checks, they are annoying when not …

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -17,7 +17,7 @@ npx concurrently \
   "npm run lint --silent" \
   "npm run check-types --silent" \
   "npm run prettier:ci --silent -- --log-level silent" \
-  "terraform -chdir=$TERRAFORM_DIRECTORY validate" \
-  "terraform -chdir=$TERRAFORM_DIRECTORY fmt"
+  # "terraform -chdir=$TERRAFORM_DIRECTORY validate" \
+  # "terraform -chdir=$TERRAFORM_DIRECTORY fmt"
 
 echo


### PR DESCRIPTION
…working with tf code

terraform code quality checks break at irregular intervals, so I've had these lines commented out for along time now. this PR just pushes those changes into main, when I need to update infra (hopefully not any time soon, I don't expect so, I just keep the blog going like it is), then I can always enable it again